### PR TITLE
Replace numpy.float with builtin float

### DIFF
--- a/widerface_evaluate/box_overlaps.pyx
+++ b/widerface_evaluate/box_overlaps.pyx
@@ -9,7 +9,7 @@ cimport cython
 import numpy as np
 cimport numpy as np
 
-DTYPE = np.float
+DTYPE = float
 ctypedef np.float_t DTYPE_t
 
 def bbox_overlaps(


### PR DESCRIPTION
`numpy.float` was deprecated in the 1.20.0 version. According to their docs `numpy.float` is identical to the builtin `float`.
Read more: https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated