### PR TITLE
Make widerface_evaluate/setup.py work on ARM64 Mac

### DIFF
--- a/widerface_evaluate/setup.py
+++ b/widerface_evaluate/setup.py
@@ -8,6 +8,23 @@ copyright@wondervictor
 from distutils.core import setup, Extension
 from Cython.Build import cythonize
 import numpy
+import platform
+import os
 
-package = Extension('bbox', ['box_overlaps.pyx'], include_dirs=[numpy.get_include()])
+extra_compile_args = []
+extra_link_args = []
+
+if platform.system() == 'Darwin' and platform.machine() == 'arm64':
+    os.environ["CFLAGS"] = "-arch arm64"
+    os.environ["ARCHFLAGS"] = "-arch arm64"
+    extra_compile_args.extend(["-arch", "arm64"])
+    extra_link_args.extend(["-arch", "arm64"])
+
+package = Extension(
+    'bbox',
+    ['box_overlaps.pyx'],
+    include_dirs=[numpy.get_include()],
+    extra_compile_args=extra_compile_args,
+    extra_link_args=extra_link_args
+)
 setup(ext_modules=cythonize([package]))


### PR DESCRIPTION
By default, bbox is built for x86_64 which does not work on Macbooks with Apple silicon. 